### PR TITLE
Removing another throw exception statement

### DIFF
--- a/creaturegodot3/creaturegodot/CreatureModule.cpp
+++ b/creaturegodot3/creaturegodot/CreatureModule.cpp
@@ -1563,7 +1563,6 @@ namespace CreatureModule {
 		if (animations.count(animation_name_in) <= 0)
 		{
 			std::cerr << "CreatureManager::PoseCreature() - Animation not found: " << animation_name_in << std::endl;
-			throw "CreatureManager::PoseCreature() - Invalid animation name!";
 			return;
 		}
 


### PR DESCRIPTION
I removed another throw exception statement. Because compilation fails for android with "throw exceptions". "throw exceptions" are only problem for android by the way. Other platforms are ok.